### PR TITLE
Fix link to SharpKeys site

### DIFF
--- a/modifiers.html
+++ b/modifiers.html
@@ -72,7 +72,7 @@
 
 Software supporting remapping of modifier keys:<br/>
 <a href="http://ahkscript.org/">AutoHotKey</a> (Windows)<br/>
-<a href="https://sharpkeys.codeplex.com/">SharpKeys</a> (Windows)<br/>
+<a href="https://github.com/randyrants/sharpkeys">SharpKeys</a> (Windows)<br/>
 <a href="https://github.com/david-janssen/kmonad">KMonad</a> (Linux, Windows, Mac)<br/>
 
 


### PR DESCRIPTION
Codeplex is just an archive now. [SharpKeys moved to GitHub.](https://github.com/randyrants/sharpkeys)